### PR TITLE
Feature/move more parameters to config

### DIFF
--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -221,7 +221,8 @@
            max-number-of-public-slaves
            public-slave-disk-allocation
            azs
-           subnet-cidr-blocks]}]
+           subnet-cidr-blocks
+           mesos-ami]}]
   (let [vpc-unique (fn [name] (str vpc-name "-" name))
         vpc-id-of (fn [type name] (id-of type (vpc-unique name)))
         cluster-identifier (str vpc-name "-" cluster-name)
@@ -369,7 +370,7 @@
 
              (asg "masters"
                   cluster-unique
-                  {:image_id current-coreos-ami
+                  {:image_id mesos-ami
                    :instance_type "m4.large"
                    :sgs (concat [(cluster-id-of "aws_security_group" "master-security-group")
                                  (cluster-id-of "aws_security_group" "admin-security-group")
@@ -448,7 +449,7 @@
 
              (asg "public-slaves"
                   cluster-unique
-                  {:image_id current-coreos-ami
+                  {:image_id mesos-ami
                    :instance_type "m4.xlarge"
                    :sgs [(cluster-id-of "aws_security_group" "public-slave-security-group")
                          (remote-output-of "vpc" "sg-sends-influx")
@@ -517,7 +518,7 @@
 
              (asg "slaves"
                   cluster-unique
-                  {:image_id current-coreos-ami
+                  {:image_id mesos-ami
                    :instance_type "m4.xlarge"
                    :sgs (concat [(cluster-id-of "aws_security_group" "slave-security-group")
                                  (remote-output-of "vpc" "sg-all-servers")

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -6,12 +6,8 @@
             [clojure.pprint :refer [pprint]]
             [clojure.set :as set]))
 
-(def account-id "165664414043")
-(def default-sgs ["allow_ssh" "allow_outbound"])
 
-(def ubuntu "ami-9b9c86f7")
-(def current-coreos-ami "ami-1807e377")
-(def ec2-ami "ami-bc5b48d0")
+(def default-sgs ["allow_ssh" "allow_outbound"])
 
 (def all-external "0.0.0.0/0")
 
@@ -229,7 +225,8 @@
                 cert_name
                 subnets
                 security-groups
-                internal]} spec
+                internal
+                account-number]} spec
         secure_protocol (if (= lb_protocol "http")
                           "https"
                           "ssl")
@@ -244,7 +241,7 @@
                                                :instance_protocol lb_protocol
                                                :lb_port 443
                                                :lb_protocol secure_protocol
-                                               :ssl_certificate_id (str "arn:aws:iam::" account-id ":server-certificate/" cert_name)}]
+                                               :ssl_certificate_id (str "arn:aws:iam::" account-number ":server-certificate/" cert_name)}]
                             [default-listener])
         listeners (concat default-listeners (:listeners spec))]
     (cluster-resource "aws_elb" name {:name name

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -26,7 +26,7 @@
                                                       :permissions "644"
                                                       :content (snippet "system-files/out-es.conf")}]}))
 
-(defn elasticsearch-cluster [name {:keys [vpc-name account-number azs] :as spec}]
+(defn elasticsearch-cluster [name {:keys [vpc-name account-number azs default-ami] :as spec}]
   ;; http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs
   ;; See for what instance-types and storage is possible
   (let [vpc-unique (fn [name] (str vpc-name "-" name))
@@ -88,7 +88,7 @@
                            {:template logstash-user-data
                             :vars {:elasticsearch-lb (id-of "aws_elb" "kibana")}})
 
-             (aws-instance (vpc-unique "logstash") {:ami ubuntu
+             (aws-instance (vpc-unique "logstash") {:ami default-ami
                                                     :vpc_security_group_ids [(vpc-id-of "aws_security_group" "logstash")
                                                                              (id-of "aws_security_group" "allow_ssh")
                                                                              (vpc-id-of "aws_security_group" "sends_influx")
@@ -99,7 +99,7 @@
                                                     })
 
              (aws-instance (vpc-unique "kibana") {
-                                                  :ami ubuntu
+                                                  :ami default-ami
                                                   :vpc_security_group_ids [(vpc-id-of "aws_security_group" "kibana")
                                                                            (vpc-id-of "aws_security_group" "allow-elb-kibana")
                                                                            (vpc-id-of "aws_security_group" "sends_influx")
@@ -131,7 +131,7 @@
                         :subnet vpc-name})
 
              (aws-instance (vpc-unique "alerts")
-                           {:ami ubuntu
+                           {:ami default-ami
                             :subnet_id (vpc-id-of "aws_subnet" "private-a")
                             :vpc_security_group_ids [(vpc-id-of "aws_security_group" "nrpe")
                                                      (id-of "aws_security_group" (str "uses-db-" (vpc-unique "alerts")))

--- a/src/terraboot/infra.clj
+++ b/src/terraboot/infra.clj
@@ -18,6 +18,7 @@
                                          :subnet-cidr-blocks {:a {:public "172.20.0.0/24"
                                                                   :private "172.20.8.0/24"}}}) "vpc/vpc.tf")
       "staging" (to-file (cluster-infra {:vpc-name vpc-name
+                                         :account-number account-number
                                          :cluster-name "staging"
                                          :min-number-of-masters 3
                                          :max-number-of-masters 3
@@ -29,7 +30,7 @@
                                          :min-number-of-public-slaves 1
                                          :max-number-of-public-slaves 1
                                          :public-slave-instance-type "t2.medium"
-                                         :public-slave-elb-listeners [{:lb_port 443 :lb_protocol "https" :port 80 :protocol "http"}
+                                         :public-slave-elb-listeners [{:lb-port 443 :lb-protocol "https" :port 80 :protocol "http" :cert-name "c512707d-bbec-4859-ab22-0f5fbad62a22"}
                                                                       {:port 9501 :protocol "http"}]
                                          :public-slave-elb-health "HTTP:9501/"
                                          :azs azs

--- a/src/terraboot/infra.clj
+++ b/src/terraboot/infra.clj
@@ -8,11 +8,14 @@
 ;; other todo: public slave port and listeners being parameters (as this is determined by applications)
 (defn generate-json [target]
   (let [account-number "165664414043"
-        azs [:a]]
+        azs [:a]
+        mesos-ami "ami-cfca25a0"
+        default-ami "ami-9b9c86f7"]
     (condp = target
       "vpc"     (to-file (vpc-vpn-infra {:vpc-name vpc-name
                                          :account-number account-number
                                          :azs azs
+                                         :default-ami default-ami
                                          :subnet-cidr-blocks {:a {:public "172.20.0.0/24"
                                                                   :private "172.20.8.0/24"}}}) "vpc/vpc.tf")
       "staging" (to-file (cluster-infra {:vpc-name vpc-name
@@ -20,11 +23,15 @@
                                          :min-number-of-masters 3
                                          :max-number-of-masters 3
                                          :master-disk-allocation 20
+                                         :master-instance-type "m4.large"
                                          :min-number-of-slaves 2
                                          :max-number-of-slaves 2
+                                         :slave-instance-type "m4.xlarge"
                                          :min-number-of-public-slaves 1
                                          :max-number-of-public-slaves 1
+                                         :public-slave-instance-type "t2.medium"
                                          :azs azs
+                                         :mesos-ami "ami-1807e377" ;; previous coreos
                                          :subnet-cidr-blocks {:a {:public "172.20.1.0/24"
                                                                   :private "172.20.9.0/24"}}}) "staging/staging.tf"))))
 

--- a/src/terraboot/infra.clj
+++ b/src/terraboot/infra.clj
@@ -5,7 +5,6 @@
 
 (def infra-path "infra/")
 
-;; other todo: public slave port and listeners being parameters (as this is determined by applications)
 (defn generate-json [target]
   (let [account-number "165664414043"
         azs [:a]
@@ -30,6 +29,9 @@
                                          :min-number-of-public-slaves 1
                                          :max-number-of-public-slaves 1
                                          :public-slave-instance-type "t2.medium"
+                                         :public-slave-elb-listeners [{:lb_port 443 :lb_protocol "https" :port 80 :protocol "http"}
+                                                                      {:port 9501 :protocol "http"}]
+                                         :public-slave-elb-health "HTTP:9501/"
                                          :azs azs
                                          :mesos-ami "ami-1807e377" ;; previous coreos
                                          :subnet-cidr-blocks {:a {:public "172.20.1.0/24"
@@ -48,6 +50,8 @@
                                                      :max-number-of-public-slaves 1
                                                      :public-slave-instance-type "m4.xlarge"
                                                      :public-slave-disk-allocation 20
+                                                     :public-slave-elb-listeners [{:lb_port 443 :lb_protocol "https" :port 80 :protocol "http"}
+                                                                                  {:port 9501}]
                                                      :mesos-ami mesos-ami
                                                      :azs azs
                                                      :subnet-cidr-blocks {:a {:public "172.20.3.0/22"

--- a/src/terraboot/infra.clj
+++ b/src/terraboot/infra.clj
@@ -33,7 +33,25 @@
                                          :azs azs
                                          :mesos-ami "ami-1807e377" ;; previous coreos
                                          :subnet-cidr-blocks {:a {:public "172.20.1.0/24"
-                                                                  :private "172.20.9.0/24"}}}) "staging/staging.tf"))))
+                                                                  :private "172.20.9.0/24"}}}) "staging/staging.tf")
+      (comment "production" (to-file (cluster-infra {:vpc-name vpc-name
+                                                     :cluster-name "production"
+                                                     :min-number-of-masters 3
+                                                     :max-number-of-masters 3
+                                                     :master-instance-type "m4.xlarge"
+                                                     :master-disk-allocation 20
+                                                     :min-number-of-slaves 3
+                                                     :max-number-of-slaves 3
+                                                     :slave-instance-type "m4.xlarge"
+                                                     :slave-disk-allocation 20
+                                                     :min-number-of-public-slaves 1
+                                                     :max-number-of-public-slaves 1
+                                                     :public-slave-instance-type "m4.xlarge"
+                                                     :public-slave-disk-allocation 20
+                                                     :mesos-ami mesos-ami
+                                                     :azs azs
+                                                     :subnet-cidr-blocks {:a {:public "172.20.3.0/22"
+                                                                              :private "172.20.10.0/22"}}}) "production/production.tf")))))
 
 
 (defn -main [target]


### PR DESCRIPTION
moves a number of things to parameters:
- ami and instances to use
- public slave elb and open port
- no default listeners, cert name in the parameters for corresponding listener

(also tightens the security on the public slaves to only allow traffic from ELB and within the VPN, and ELB to just have the relevant ports open)
