### PR TITLE
Feature/filebeat on slaves

### DIFF
--- a/resources/system-files/filebeat.yml
+++ b/resources/system-files/filebeat.yml
@@ -1,0 +1,10 @@
+filebeat:
+  prospectors:
+    -
+      paths:
+        - /var/lib/mesos/slave/slaves/*/frameworks/*/executors/*/runs/latest/stdout
+        - /var/lib/mesos/slave/slaves/*/frameworks/*/executors/*/runs/latest/stderr
+
+output:
+  logstash:
+    hosts: ["${logstash-ip}:9200"]

--- a/resources/system-files/install-filebeat.sh
+++ b/resources/system-files/install-filebeat.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+curl -o /home/core/filebeat-1.2.3-x86_64.tar.gz https://download.elastic.co/beats/filebeat/filebeat-1.2.3-x86_64.tar.gz
+tar xvzf /home/core/filebeat-1.2.3-x86_64.tar.gz
+mkdir -p /opt/bin
+cp /home/core/filebeat-1.2.3-x86_64/filebeat /opt/bin/

--- a/resources/systemd/filebeat.service
+++ b/resources/systemd/filebeat.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Filebeat
-Documentation=filebeat systemctl
 Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/home/core/filebeat-1.2.1-x86_64/filebeat -c /home/core/filebeat-1.2.1-x86_64/filebeat.yml
+ExecStart=/opt/bin/filebeat -c /etc/filebeat/filebeat.yml
 Restart=always

--- a/resources/systemd/filebeat.service
+++ b/resources/systemd/filebeat.service
@@ -4,5 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+TimeoutStartSec=15
+ExecStartPre=/home/core/install-filebeat.sh >> /home/core/filebeat-install.log 2>&1
 ExecStart=/opt/bin/filebeat -c /etc/filebeat/filebeat.yml
 Restart=always

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -473,16 +473,6 @@
                                                     (remote-output-of "vpc" "sg-allow-http-https")]
                                                    remote-default-sgs)}]})
 
-             (route53_record (cluster-unique "deploy")
-                             {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
-                                      :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
-                                      :evaluate_target_health true}})
-
-             (route53_record cluster-identifier
-                             {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
-                                      :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
-                                      :evaluate_target_health true}})
-
              (cluster-resource "template_file" "slave-user-data"
                                {:template (mesos-slave-user-data)
                                 :vars {:aws-region region
@@ -532,5 +522,4 @@
              (local-deploy-scripts {:cluster-name cluster-name
                                     :name-fn cluster-unique
                                     :min-number-of-slaves min-number-of-slaves
-                                    :internal-lb (cluster-output-of "aws_elb" "internal-lb" "dns_name")})
-             ))))
+                                    :internal-lb (cluster-output-of "aws_elb" "internal-lb" "dns_name")})))))

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -78,11 +78,12 @@
   {:coreos {:units [{:name "filebeat.service" :command "start" :content (snippet "systemd/filebeat.service")}]}
    :write_files [{:path "/etc/filebeat/filebeat.yml"
                   :content (snippet "system-files/filebeat.yml")}]
-   :runcmd ["curl -o /home/core/filebeat-1.2.3-x86_64.tar.gz https://download.elastic.co/beats/filebeat/filebeat-1.2.3-x86_64.tar.gz"
-            "tar xvzf /home/core/filebeat-1.2.3-x86_64.tar.gz"
-            "mkdir -p /opt/bin"
-            "cp /home/core/filebeat-1.2.3-x86_64/filebeat /opt/bin/"
-            "mkdir -p /etc/filebeat"]})
+   :runcmd (mapv #(str % "  >> /var/log/filebeat-install.log 2>&1")
+                 ["curl -o /home/core/filebeat-1.2.3-x86_64.tar.gz https://download.elastic.co/beats/filebeat/filebeat-1.2.3-x86_64.tar.gz"
+                  "tar xvzf /home/core/filebeat-1.2.3-x86_64.tar.gz"
+                  "mkdir -p /opt/bin"
+                  "cp /home/core/filebeat-1.2.3-x86_64/filebeat /opt/bin/"
+                  "mkdir -p /etc/filebeat"])})
 
 (defn mesos-slave-user-data
   []

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -501,9 +501,7 @@
                                        :mesos-dns (cluster-output-of "aws_elb" "internal-lb" "dns_name")
                                        :alerts-server (str "alerts." (vpc/vpc-dns-zone vpc-name))
                                        :logstash-ip (remote-output-of "vpc" "logstash-ip")}
-                                :lifecycle { :create_before_destroy true }
-
-                                })
+                                :lifecycle { :create_before_destroy true }})
 
 
              (asg "slaves"

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -76,14 +76,11 @@
 
 (def filebeat-user-data
   {:coreos {:units [{:name "filebeat.service" :command "start" :content (snippet "systemd/filebeat.service")}]}
-   :write_files [{:path "/etc/filebeat/filebeat.yml"
-                  :content (snippet "system-files/filebeat.yml")}]
-   :runcmd (mapv #(str % "  >> /var/log/filebeat-install.log 2>&1")
-                 ["curl -o /home/core/filebeat-1.2.3-x86_64.tar.gz https://download.elastic.co/beats/filebeat/filebeat-1.2.3-x86_64.tar.gz"
-                  "tar xvzf /home/core/filebeat-1.2.3-x86_64.tar.gz"
-                  "mkdir -p /opt/bin"
-                  "cp /home/core/filebeat-1.2.3-x86_64/filebeat /opt/bin/"
-                  "mkdir -p /etc/filebeat"])})
+   :write_files [{:path "/home/core/install-filebeat.sh"
+                  :content (snippet "system-files/install-filebeat.sh")
+                  :permissions "0644"}
+                 {:path "/etc/filebeat/filebeat.yml"
+                  :content (snippet "system-files/filebeat.yml")}]})
 
 (defn mesos-slave-user-data
   []

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -430,7 +430,7 @@
                                        :influxdb-dns (str "influxdb." (vpc/vpc-dns-zone vpc-name))
                                        :mesos-dns (cluster-output-of "aws_elb" "internal-lb" "dns_name")
                                        :alerts-server (str "alerts." (vpc/vpc-dns-zone vpc-name))
-                                       :logstash-ip (vpc-output-of "aws_eip" "logstash" "public_ip")}
+                                       :logstash-ip (remote-output-of "vpc" "logstash-ip")}
                                 :lifecycle { :create_before_destroy true }})
 
              (vpc/private_route53_record (str cluster-name "-masters") vpc-name
@@ -500,7 +500,7 @@
                                        :influxdb-dns (str "influxdb." (vpc/vpc-dns-zone vpc-name))
                                        :mesos-dns (cluster-output-of "aws_elb" "internal-lb" "dns_name")
                                        :alerts-server (str "alerts." (vpc/vpc-dns-zone vpc-name))
-                                       :logstash-ip (vpc-output-of "aws_eip" "logstash" "public_ip")}
+                                       :logstash-ip (remote-output-of "vpc" "logstash-ip")}
                                 :lifecycle { :create_before_destroy true }
 
                                 })

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -241,15 +241,15 @@
            public-slave-elb-sg
            public-slave-elb-health
            account-number]}]
-  (let [vpc-unique (fn [name] (str vpc-name "-" name))
-        vpc-id-of (fn [type name] (id-of type (vpc-unique name)))
-        vpc-output-of (fn [type name & values] (apply (partial output-of type (vpc-unique name)) values))
-        cluster-identifier (str vpc-name "-" cluster-name)
-        cluster-unique (fn [name] (str cluster-identifier "-" name))
+  (let [vpc-unique (vpc-unique-fn vpc-name)
+        vpc-id-of (id-of-fn vpc-unique)
+        vpc-output-of (output-of-fn vpc-unique)
+        cluster-identifier (cluster-identifier vpc-name cluster-name)
+        cluster-unique (cluster-unique-fn vpc-name cluster-name)
         cluster-resource (partial resource cluster-unique)
         cluster-security-group (partial scoped-security-group cluster-unique)
-        cluster-id-of (fn [type name] (id-of type (cluster-unique name)))
-        cluster-output-of (fn [type name & values] (apply (partial output-of type (cluster-unique name)) values))
+        cluster-id-of (id-of-fn cluster-unique)
+        cluster-output-of (output-of-fn cluster-unique)
         private-subnets (mapv #(cluster-id-of "aws_subnet" (stringify "private-" %)) azs)
         public-subnets (mapv #(cluster-id-of "aws_subnet" (stringify "public-" %)) azs)
         elb-listener (account-elb-listener account-number)]

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -4,7 +4,7 @@
             [stencil.core :as mustache]
             [clj-yaml.core :as yaml]
             [clojure.pprint :refer [pprint]]
-            [clojure.set :as set]))
+            [terraboot.utils :refer :all]))
 
 
 (def default-sgs ["allow_ssh" "allow_outbound"])
@@ -15,28 +15,6 @@
 
 (def dns-zone "mastodonc.net")
 (def dns-zone-id "Z1EFD0WXZUIXYT")
-
-(letfn [(sensitive-merge-in*
-          [mfns]
-          (fn [a b]
-            (if (map? a)
-              (do (when-let [dups (seq (set/intersection (set (keys a)) (set (keys b))))]
-                    (throw (Exception. (str "Duplicate keys: " dups))))
-                  (merge-with ((first mfns) (rest mfns)) a b))
-              b)))
-        (merge-in*
-          [mfns]
-          (fn [a b]
-            (if (map? a)
-              (merge-with ((first mfns) (rest mfns)) a b)
-              b)))
-        (merge-with-fn-seq
-          [fn-seq]
-          (partial merge-with
-                   ((first fn-seq) (rest fn-seq))))]
-  ;; todo rediscover duplicates but not for the :output tree
-  (def merge-in
-    (merge-with-fn-seq (repeat merge-in*))))
 
 (defn output-of [type resource-name & values]
   (str "${"

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -341,6 +341,29 @@
                    {:port 5432
                     :source_security_group_id (id-of "aws_security_group" (str "uses-db-" name))})))
 
+(defn vpc-unique-fn
+  "namespacing vpc resources"
+  [vpc-name]
+  (fn [name] (str vpc-name "-" name)))
+
+(defn cluster-identifier
+  [vpc-name cluster-name]
+  (str vpc-name "-" cluster-name))
+
+(defn cluster-unique-fn
+  "namespacing cluster resources"
+  [vpc-name cluster-name]
+  (let [cluster-identifier (cluster-identifier vpc-name cluster-name)]
+    (fn [name] (str cluster-identifier "-" name))))
+
+(defn output-of-fn
+  [naming-fn]
+  (fn [type name & values] (apply (partial output-of type (naming-fn name)) values)))
+
+(defn id-of-fn
+  [naming-fn]
+  (fn [type name] (id-of type (naming-fn name))))
+
 (defn remote-state [name]
   (resource "terraform_remote_state" name
             {:backend "s3"

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -13,9 +13,6 @@
 
 (def region "eu-central-1")
 
-(def dns-zone "mastodonc.net")
-(def dns-zone-id "Z1EFD0WXZUIXYT")
-
 (defn output-of [type resource-name & values]
   (str "${"
        (name type) "."
@@ -133,15 +130,7 @@
 (defn safe-name [s]
   (string/replace s #"\." "__"))
 
-(defn route53_record [prefix spec]
-  (let [name (str prefix "." dns-zone)]
-    (resource "aws_route53_record" (safe-name name)
-              (merge
-               {:zone_id dns-zone-id
-                :name name
-                :type "A"}
-               (if (:alias spec) {} {:ttl "300"})
-               spec))))
+
 
 (defn aws-instance [name spec]
   (let [default-sg-ids (map (partial id-of "aws_security_group") default-sgs)]

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -72,15 +72,13 @@
                                   :protocol "udp"
                                   :cidr_blocks (mapv #(str (vpc-output-of "aws_eip" (stringify "public-" % "-nat") "public_ip") "/32") azs)}
                                  {:port 9200
-                                  :protocol "udp"
-                                  :cidr_blocks [all-external]})
+                                  :protocol "tcp"
+                                  :cidr_blocks [vpc-cidr-block]})
 
              (vpc-resource "aws_eip" "logstash"
                            {:vpc true
                             :instance (vpc-id-of "aws_instance" "logstash")})
 
-
-             (route53_record "logstash" {:records [(vpc-output-of "aws_eip" "logstash" "public_ip")]})
 
              (vpc-security-group "sends_gelf" {})
 
@@ -161,13 +159,6 @@
              (vpc-security-group "allow-elb-alerts" {}
                                  {:port 80
                                   :source_security_group_id (vpc-id-of "aws_security_group" "elb-alerts")})
-
-             (route53_record "alerts" {:type "CNAME"
-                                       :records [(output-of "aws_elb" "alerts" "dns_name")]})
-
-
-             (route53_record "kibana" {:type "CNAME"
-                                       :records [(output-of "aws_elb" "kibana" "dns_name")]})
 
              (vpc-security-group "elb-kibana" {}
                                  {:port 80

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -1,5 +1,6 @@
 (ns terraboot.elasticsearch
   (:require [terraboot.core :refer :all]
+            [terraboot.utils :refer :all]
             [terraboot.cloud-config :refer [cloud-config]]
             [cheshire.core :as json]))
 

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -30,10 +30,10 @@
 (defn elasticsearch-cluster [name {:keys [vpc-name account-number azs default-ami vpc-cidr-block] :as spec}]
   ;; http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs
   ;; See for what instance-types and storage is possible
-  (let [vpc-unique (fn [name] (str vpc-name "-" name))
+  (let [vpc-unique (vpc-unique-fn vpc-name)
         vpc-resource (partial resource vpc-unique)
-        vpc-id-of (fn [type name] (id-of type (vpc-unique name)))
-        vpc-output-of (fn [type name & values] (apply (partial output-of type (vpc-unique name)) values))
+        vpc-id-of (id-of-fn vpc-unique)
+        vpc-output-of (output-of-fn vpc-unique)
         vpc-security-group (partial scoped-security-group vpc-unique)
         elb-listener (account-elb-listener account-number)]
     (merge-in

--- a/src/terraboot/infra.clj
+++ b/src/terraboot/infra.clj
@@ -1,6 +1,7 @@
 (ns terraboot.infra
   (:require [terraboot.core :refer :all]
             [terraboot.vpc :refer [vpc-vpn-infra vpc-name]]
+            [terraboot.public-dns :as dns]
             [terraboot.cluster :refer [cluster-infra]]
             [clojure.edn :as edn]))
 
@@ -17,40 +18,44 @@
         mesos-ami "ami-cfca25a0"
         default-ami "ami-9b9c86f7"
         vpc-cidr-block "172.20.0.0/20"
-        ]
+        dns-zone "mastodonc.net"
+        dns-zone-id "Z1EFD0WXZUIXYT"]
     (condp = target
-      "vpc"     (to-file (vpc-vpn-infra {:vpc-name vpc-name
-                                         :vpc-cidr-block vpc-cidr-block
-                                         :account-number account-number
-                                         :azs [:a :b]
-                                         :default-ami default-ami
-                                         :subnet-cidr-blocks {:a {:public "172.20.0.0/24"
-                                                                  :private "172.20.8.0/24"}
-                                                              :b {:public "172.20.1.0/24"
-                                                                  :private "172.20.9.0/24"}}}) "vpc/vpc.tf")
-      "staging" (to-file (cluster-infra {:vpc-name vpc-name
-                                         :vpc-cidr-block vpc-cidr-block
-                                         :account-number account-number
-                                         :cluster-name "staging"
-                                         :min-number-of-masters 3
-                                         :max-number-of-masters 3
-                                         :master-disk-allocation 20
-                                         :master-instance-type "m4.large"
-                                         :min-number-of-slaves 2
-                                         :max-number-of-slaves 2
-                                         :slave-instance-type "m4.xlarge"
-                                         :min-number-of-public-slaves 1
-                                         :max-number-of-public-slaves 1
-                                         :public-slave-instance-type "t2.medium"
-                                         :public-slave-elb-listeners [{:port 80 :protocol "http"}
-                                                                      {:port 9501 :protocol "http"}]
-                                         :public-slave-elb-sg [{:port 9501 :cidr_blocks [all-external]}
-                                                               {:port 80 :cidr_blocks [all-external]}]
-                                         :public-slave-elb-health "HTTP:9501/"
-                                         :azs azs
-                                         :mesos-ami "ami-1807e377" ;; previous coreos
-                                         :subnet-cidr-blocks {:a {:public "172.20.2.0/24"
-                                                                  :private "172.20.10.0/24"}}}) "staging/staging.tf")
+      "vpc"     (do (to-file (vpc-vpn-infra {:vpc-name vpc-name
+                                             :vpc-cidr-block vpc-cidr-block
+                                             :account-number account-number
+                                             :azs [:a :b]
+                                             :default-ami default-ami
+                                             :subnet-cidr-blocks {:a {:public "172.20.0.0/24"
+                                                                      :private "172.20.8.0/24"}
+                                                                  :b {:public "172.20.1.0/24"
+                                                                      :private "172.20.9.0/24"}}}) "vpc/vpc.tf")
+                    (to-file (dns/vpc-public-dns dns-zone dns-zone-id vpc-name) "vpc/vpc-dns.tf"))
+
+      "staging" (do (to-file (cluster-infra {:vpc-name vpc-name
+                                             :vpc-cidr-block vpc-cidr-block
+                                             :account-number account-number
+                                             :cluster-name "staging"
+                                             :min-number-of-masters 3
+                                             :max-number-of-masters 3
+                                             :master-disk-allocation 20
+                                             :master-instance-type "m4.large"
+                                             :min-number-of-slaves 2
+                                             :max-number-of-slaves 2
+                                             :slave-instance-type "m4.xlarge"
+                                             :min-number-of-public-slaves 1
+                                             :max-number-of-public-slaves 1
+                                             :public-slave-instance-type "t2.medium"
+                                             :public-slave-elb-listeners [{:port 80 :protocol "http"}
+                                                                          {:port 9501 :protocol "http"}]
+                                             :public-slave-elb-sg [{:port 9501 :cidr_blocks [all-external]}
+                                                                   {:port 80 :cidr_blocks [all-external]}]
+                                             :public-slave-elb-health "HTTP:9501/"
+                                             :azs azs
+                                             :mesos-ami "ami-1807e377" ;; previous coreos
+                                             :subnet-cidr-blocks {:a {:public "172.20.2.0/24"
+                                                                      :private "172.20.10.0/24"}}}) "staging/staging.tf")
+                    (to-file (dns/cluster-public-dns dns-zone dns-zone-id vpc-name "staging") "staging/staging-dns.tf"))
       (comment "production" (to-file (cluster-infra {:vpc-name vpc-name
                                                      :cluster-name "production"
                                                      :min-number-of-masters 3

--- a/src/terraboot/public_dns.clj
+++ b/src/terraboot/public_dns.clj
@@ -1,0 +1,42 @@
+(ns terraboot.public-dns
+  (:require [terraboot.core :as core]
+            [terraboot.utils :as utils]))
+
+(defn public-route53-record [dns-zone dns-zone-id prefix spec]
+  (let [name (str prefix "." dns-zone)]
+    (core/resource "aws_route53_record" (core/safe-name name)
+                   (merge
+                    {:zone_id dns-zone-id
+                     :name name
+                     :type "A"}
+                    (if (:alias spec) {} {:ttl "300"})
+                    spec))))
+
+(defn vpc-public-dns
+  [dns-zone dns-zone-id vpc-name]
+  (let [route53-record (partial public-route53-record dns-zone dns-zone-id)
+        vpc-output-of (core/output-of-fn (core/vpc-unique-fn vpc-name))]
+    (utils/merge-in
+     (route53-record "vpn" {:records [(vpc-output-of "aws_instance" "vpn" "public_ip")]})
+     (route53-record "logstash" {:records [(vpc-output-of "aws_eip" "logstash" "public_ip")]})
+     (route53-record "grafana" {:type "CNAME"
+                                :records [(core/output-of "aws_elb" "grafana" "dns_name")]})
+     (route53-record "influxdb" {:records [(core/output-of "aws_eip" "influxdb" "public_ip")]})
+     (route53-record "alerts" {:type "CNAME"
+                               :records [(core/output-of "aws_elb" "alerts" "dns_name")]}))))
+
+(defn cluster-public-dns
+  [dns-zone dns-zone-id vpc-name cluster-name]
+  (let [route53-record (partial public-route53-record dns-zone dns-zone-id)
+        cluster-identifier (core/cluster-identifier vpc-name cluster-name)
+        cluster-unique (core/cluster-unique-fn vpc-name cluster-name)
+        cluster-output-of (core/output-of-fn cluster-unique)]
+    (utils/merge-in
+     (route53-record (cluster-unique "deploy")
+                     {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
+                              :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
+                              :evaluate_target_health true}})
+     (route53-record cluster-identifier
+                     {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
+                              :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
+                              :evaluate_target_health true}}))))

--- a/src/terraboot/utils.clj
+++ b/src/terraboot/utils.clj
@@ -1,0 +1,36 @@
+(ns terraboot.utils
+  (require [clojure.set :as set]))
+
+(letfn [(sensitive-merge-in*
+          [mfns]
+          (fn [a b]
+            (if (map? a)
+              (do (when-let [dups (seq (set/intersection (set (keys a)) (set (keys b))))]
+                    (throw (Exception. (str "Duplicate keys: " dups))))
+                  (merge-with ((first mfns) (rest mfns)) a b))
+              b)))
+        (merge-in*
+          [mfns]
+          (fn [a b]
+            (if (map? a)
+              (merge-with ((first mfns) (rest mfns)) a b)
+              b)))
+        (merge-with-fn-seq
+          [fn-seq]
+          (partial merge-with
+                   ((first fn-seq) (rest fn-seq))))]
+  ;; todo rediscover duplicates but not for the :output tree
+  (def merge-in
+    (merge-with-fn-seq (repeat merge-in*))))
+
+;; this is copy pasta from http://dev.clojure.org/jira/browse/CLJ-1468 and is used in some utility libraries
+(defn deep-merge-with
+  "Like merge-with, but merges maps recursively, applying the given fn only when there's a non-map at a particular level."
+  {:added "1.7"}
+  [f & maps]
+  (apply
+   (fn m [& maps]
+     (if (every? map? maps)
+       (apply merge-with m maps)
+       (apply f maps)))
+   maps))

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -97,10 +97,10 @@
            subnet-cidr-blocks
            default-ami
            vpc-cidr-block]} ]
-  (let [vpc-unique (fn [name] (str vpc-name "-" name))
+  (let [vpc-unique (vpc-unique-fn vpc-name)
         vpc-resource (partial resource vpc-unique)
-        vpc-id-of (fn [type name] (id-of type (vpc-unique name)))
-        vpc-output-of (fn [type name & values] (apply (partial output-of type (vpc-unique name)) values))
+        vpc-id-of (id-of-fn vpc-unique)
+        vpc-output-of (output-of-fn vpc-unique)
         vpc-security-group (partial scoped-security-group vpc-unique)
         elb-listener (account-elb-listener account-number)]
     (merge-in

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -1,5 +1,6 @@
 (ns terraboot.vpc
   (:require [terraboot.core :refer :all]
+            [terraboot.utils :refer :all]
             [terraboot.cloud-config :refer [cloud-config]]
             [terraboot.elasticsearch :refer [elasticsearch-cluster]]
             [clojure.string :as string]))

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -273,4 +273,5 @@
              (output "sg-sends-gelf" "aws_security_group" (vpc-unique "sends_gelf") "id")
              (output "private-dns-zone" "aws_route53_zone" (vpc-unique "mesos") "id")
              (output "public-route-table" "aws_route_table" (vpc-unique "public") "id")
+             (output "logstash-ip" "aws_eip" (vpc-unique "logstash") "public_ip")
              ))))

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -136,7 +136,7 @@
                                        :instance_type "m4.large"
                                        :vpc_security_group_ids [(vpc-id-of "aws_security_group" "influxdb")
                                                                 (id-of "aws_security_group" "allow_ssh")
-                                                                (vpc-id-of "aws_security_group" "allow_elb_chronograf")
+                                                                (vpc-id-of "aws_security_group" "allow_elb_grafana")
                                                                 (vpc-id-of "aws_security_group" "all-servers")
                                                                 ]
                                        :subnet_id (vpc-id-of "aws_subnet" (stringify "public-" (first azs)))})
@@ -146,19 +146,19 @@
                             :instance_id (id-of "aws_instance" "influxdb")
                             :volume_id (vpc-id-of "aws_ebs_volume" "influxdb")})
 
-             (elb "chronograf" resource {:name "chronograf"
-                                         :health_check {:healthy_threshold 2
-                                                        :unhealthy_threshold 3
-                                                        :target "HTTP:80/status"
-                                                        :timeout 5
-                                                        :interval 30}
-                                         :listeners [(elb-listener {:lb-port 443 :lb-protocol "https" :port 80 :protocol "http" :cert-name "StartMastodoncNet"})]
-                                         :instances [(id-of "aws_instance" "influxdb")]
-                                         :subnets (mapv #(id-of "aws_subnet" (stringify  vpc-name "-public-" %)) azs)
-                                         :security-groups (mapv #(id-of "aws_security_group" %) [(vpc-unique "all-servers")
-                                                                                                 "allow_external_http_https"
-                                                                                                 (vpc-unique "elb_chronograf")])
-                                         })
+             (elb "grafana" resource {:name "grafana"
+                                      :health_check {:healthy_threshold 2
+                                                     :unhealthy_threshold 3
+                                                     :target "HTTP:80/status"
+                                                     :timeout 5
+                                                     :interval 30}
+                                      :listeners [(elb-listener {:lb-port 443 :lb-protocol "https" :port 80 :protocol "http" :cert-name "StartMastodoncNet"})]
+                                      :instances [(id-of "aws_instance" "influxdb")]
+                                      :subnets (mapv #(id-of "aws_subnet" (stringify  vpc-name "-public-" %)) azs)
+                                      :security-groups (mapv #(id-of "aws_security_group" %) [(vpc-unique "all-servers")
+                                                                                              "allow_external_http_https"
+                                                                                              (vpc-unique "elb_grafana")])
+                                      })
 
              (private_route53_record "influxdb" vpc-name {:records [(output-of "aws_instance" "influxdb" "private_ip")]})
 
@@ -166,13 +166,10 @@
 
              (private_route53_record "alerts" vpc-name {:records [(vpc-output-of "aws_instance" "alerts" "private_ip")]})
 
-             (route53_record "chronograf" {:type "CNAME"
-                                           :records [(output-of "aws_elb" "chronograf" "dns_name")]})
-
-             (vpc-security-group "elb_chronograf" {})
-             (vpc-security-group "allow_elb_chronograf" {}
+             (vpc-security-group "elb_grafana" {})
+             (vpc-security-group "allow_elb_grafana" {}
                                  {:port 80
-                                  :source_security_group_id (vpc-id-of "aws_security_group" "elb_chronograf")})
+                                  :source_security_group_id (vpc-id-of "aws_security_group" "elb_grafana")})
 
              (vpc-security-group "influxdb" {}
                                  {:port 222
@@ -188,12 +185,8 @@
                        {:vpc true
                         :instance (id-of "aws_instance" "influxdb")})
 
-             (route53_record "influxdb" { :records [(output-of "aws_eip" "influxdb" "public_ip")]})
-
-             #_(vpc-resource "aws_eip" "vpn" {:instance (vpc-id-of "aws_instance" "vpn")
-                                              :vpc true})
-
-             (route53_record "vpn" {:records [(vpc-output-of "aws_instance" "vpn" "public_ip")]})
+             (vpc-resource "aws_eip" "vpn" {:instance (vpc-id-of "aws_instance" "vpn")
+                                            :vpc true})
 
              (vpc-resource "aws_route53_zone" "mesos"
                            {:name "vpc.kixi"


### PR DESCRIPTION
- adding filebeat on slaves and public slaves
- separate out public dns in preparation of terraboot the library (since not all customers want/need public dns)
