### PR TITLE
Feature/production migration

### DIFF
--- a/resources/system-files/backup-witan.sh
+++ b/resources/system-files/backup-witan.sh
@@ -16,4 +16,4 @@ fi
 
 # We only want the snapshots dirs
 # For filters rationale see http://docs.aws.amazon.com/cli/latest/reference/s3/index.html#use-of-exclude-and-include-filters
-sudo -u core $AWS --profile backup s3 sync --exclude '*' --include '*/snapshots/*' $${CASSANDRA_DATA_DIR} s3://witan-cassandra-backup/$(hostname)/ --region eu-central-1
+sudo -u core $AWS s3 sync --exclude '*' --include '*/snapshots/*' $${CASSANDRA_DATA_DIR} s3://witan-cassandra-backup/$(hostname)/ --region eu-central-1

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -444,7 +444,8 @@
                    :sgs [(cluster-id-of "aws_security_group" "public-slave-security-group")
                          (remote-output-of "vpc" "sg-sends-influx")
                          (remote-output-of "vpc" "sg-sends-gelf")
-                         (remote-output-of "vpc" "sg-all-servers")]
+                         (remote-output-of "vpc" "sg-all-servers")
+                         (remote-output-of "vpc" "sg-allow-ssh")]
                    :role (cluster-unique "slave-role")
                    :public_ip true
                    :tags {:Key "role"

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -177,8 +177,9 @@
 
 (defn account-elb-listener[account-number]
   (fn [{:keys [port lb-port protocol lb-protocol cert-name cert-id]}]
-    (let [cert-id (or cert-id (str "arn:aws:iam::" account-number ":server-certificate/" cert-name))
-          add-cert-if-present #(if (or cert-name cert-id) (assoc % :ssl_certificate_id cert-id) %)]
+    (let [iam-cert-id (str "arn:aws:iam::" account-number ":server-certificate/" cert-name)
+          cert (if cert-name iam-cert-id cert-id)
+          add-cert-if-present #(if cert (assoc % :ssl_certificate_id cert) %)]
       (add-cert-if-present {:instance_port port
                             :instance_protocol protocol
                             :lb_port (or lb-port port)

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -176,9 +176,9 @@
 
 
 (defn account-elb-listener[account-number]
-  (fn [{:keys [port lb-port protocol lb-protocol cert-name]}]
-    (let [cert-id (str "arn:aws:iam::" account-number ":server-certificate/" cert-name)
-          add-cert-if-present #(if cert-name (assoc % :ssl_certificate_id cert-id) %)]
+  (fn [{:keys [port lb-port protocol lb-protocol cert-name cert-id]}]
+    (let [cert-id (or cert-id (str "arn:aws:iam::" account-number ":server-certificate/" cert-name))
+          add-cert-if-present #(if (or cert-name cert-id) (assoc % :ssl_certificate_id cert-id) %)]
       (add-cert-if-present {:instance_port port
                             :instance_protocol protocol
                             :lb_port (or lb-port port)
@@ -261,7 +261,7 @@
                             :load_balancers (mapv #(cluster-output-of "aws_elb" (:name %) "name") (:elb spec))
                             :tag {
                                   :key "Name"
-                                  :value (str "autoscale-" name)
+                                  :value (name-fn name)
                                   :propagate_at_launch true
                                   }}))]
     (merge-in asg-config

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -212,7 +212,7 @@
 
              (security-group "allow_ssh" {}
                              {:port 22
-                              :cidr_blocks [all-external]
+                              :cidr_blocks [vpc-cidr-block]
                               })
 
              (security-group "allow_external_http_https" {}


### PR DESCRIPTION
- security group for ssh added to public slave
- security group for ssh restricted to vpc addresses
- backup script no longer requires specific aws cli profile but uses the instance's IAM role
- (tentative) tag for instances changed to something more expressive than autoscale-\* (would require recreating instances so not actually executed yet)
