### PR TITLE
getting errors caught and interpreted for apps

### DIFF
--- a/resources/system-files/filebeat.yml
+++ b/resources/system-files/filebeat.yml
@@ -5,6 +5,14 @@ filebeat:
         - /var/lib/mesos/slave/slaves/*/frameworks/*/executors/*/runs/latest/stdout
         - /var/lib/mesos/slave/slaves/*/frameworks/*/executors/*/runs/latest/stderr
 
+multiline:
+    pattern: '^[[:space:]]+|^Caused by:'
+    negate: false
+    match: after
+
+fields:
+    tag: '%{cluster-name}'
+ 
 output:
   logstash:
-    hosts: ["${logstash-ip}:9200"]
+    hosts: ["172.20.0.36:9200"]

--- a/resources/system-files/filebeat.yml
+++ b/resources/system-files/filebeat.yml
@@ -12,7 +12,7 @@ multiline:
 
 fields:
     tag: '%{cluster-name}'
- 
+
 output:
   logstash:
-    hosts: ["172.20.0.36:9200"]
+    hosts: ["${logstash-ip}:9200"]

--- a/resources/vpc-logstash/basic-patterns
+++ b/resources/vpc-logstash/basic-patterns
@@ -1,0 +1,44 @@
+# Months: January, Feb, 3, 03, 12, December
+MONTH \b(?:[Jj]an(?:uary|uar)?|[Ff]eb(?:ruary|ruar)?|[Mm](?:a|ä)?r(?:ch|z)?|[Aa]pr(?:il)?|[Mm]a(?:y|i)?|[Jj]un(?:e|i)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo](?:c|k)?t(?:ober)?|[Nn]ov(?:ember)?|[Dd]e(?:c|z)(?:ember)?)\b
+MONTHNUM (?:0?[1-9]|1[0-2])
+MONTHNUM2 (?:0[1-9]|1[0-2])
+MONTHDAY (?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])
+
+# Days: Monday, Tue, Thu, etc...
+DAY (?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)
+
+# Years?
+YEAR (?>\d\d){1,2}
+HOUR (?:2[0123]|[01]?[0-9])
+MINUTE (?:[0-5][0-9])
+# '60' is a leap second in most time standards and thus is valid.
+SECOND (?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?)
+TIME (?!<[0-9])%{HOUR}:%{MINUTE}(?::%{SECOND})(?![0-9])
+# datestamp is YYYY/MM/DD-HH:MM:SS.UUUU (or something like it)
+DATE_US %{MONTHNUM}[/-]%{MONTHDAY}[/-]%{YEAR}
+DATE_EU %{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}
+ISO8601_TIMEZONE (?:Z|[+-]%{HOUR}(?::?%{MINUTE}))
+ISO8601_SECOND (?:%{SECOND}|60)
+TIMESTAMP_ISO8601 %{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND})?%{ISO8601_TIMEZONE}?
+DATE %{DATE_US}|%{DATE_EU}
+DATESTAMP %{DATE}[- ]%{TIME}
+TZ (?:[APMCE][SD]T|UTC)
+DATESTAMP_RFC822 %{DAY} %{MONTH} %{MONTHDAY} %{YEAR} %{TIME} %{TZ}
+DATESTAMP_RFC2822 %{DAY}, %{MONTHDAY} %{MONTH} %{YEAR} %{TIME} %{ISO8601_TIMEZONE}
+DATESTAMP_OTHER %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{TZ} %{YEAR}
+DATESTAMP_EVENTLOG %{YEAR}%{MONTHNUM2}%{MONTHDAY}%{HOUR}%{MINUTE}%{SECOND}
+HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
+
+# logback
+LOGBACK_TIMESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND},%{MSECOND}
+
+# Log Levels
+LOGLEVEL ([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)
+
+# 2016-07-13 14:52:30,996 ERROR whiner.handler -
+JAVACLASS (?:[a-z-]+\.)[A-Za-z0-9]+
+JAVAFILE (?:[A-Za-z0-9_.-]})
+JAVASTACKTRACEPART "at %{JAVACLASS:class}\.%{WORD:method}\(%{JAVAFILE:file}:%{NUMBER:line}\)
+MILLISECOND (\d{3})
+JAVALOGBACKTIMESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY}[T ]%{HOUR}:?%{MINUTE}(?::?%{SECOND}),%{MILLISECOND}
+JAVALOGBACK %{JAVALOGBACKTIMESTAMP:timestamp} (?:%{WORD:severity})

--- a/resources/vpc-logstash/in-beats.conf
+++ b/resources/vpc-logstash/in-beats.conf
@@ -1,6 +1,10 @@
 input{
     beats {
         port => 9200
+        codec => multiline {
+          pattern => "^\s"
+          what => "previous"
+        }
     }
 }
 

--- a/resources/vpc-logstash/in-beats.conf
+++ b/resources/vpc-logstash/in-beats.conf
@@ -2,9 +2,10 @@ input{
     beats {
         port => 9200
         codec => multiline {
-          pattern => "^\s"
+          patterns_dir => ["/opt/logstash/patterns"]
+          pattern => "^%{LOGLEVEL} "
+          negate => true
           what => "previous"
         }
     }
 }
-

--- a/resources/vpc-logstash/in-gelf.conf
+++ b/resources/vpc-logstash/in-gelf.conf
@@ -6,12 +6,23 @@ input {
 }
 
 filter {
+  if [type] == "docker" {
     multiline {
-      pattern => "^%{TIMESTAMP_ISO8601}"
+      patterns_dir => ["/opt/logstash/patterns"]
+      pattern => "^%{JAVALOGBACKTIMESTAMP}"
       negate => true
-      what => "previous"
-      source => "short_message"
-      stream_identity => "%{host}.%{container_id}"
+      what => previous
     }
-}
+	  grok {
+	    match => {"message" =>  "%{JAVALOGBACK}"}
+	  }
 
+	  date {
+	    match => ["timestamp", "yyyy-MM-dd HH:mm:ss,SSS"]
+	  }
+
+	  #mutate {
+	  #  add_field => ["level", "%{severity}"]
+	  #}
+  }
+}

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -104,8 +104,7 @@
                                  {:write_files [{:path "/etc/mesosphere/roles/slave_public"
                                                  :content ""}
                                                 {:path "/etc/mesosphere/roles/aws"
-                                                 :content ""}]}
-                                 filebeat-user-data)))
+                                                 :content ""}]})))
 
 (defn exhibitor-bucket-policy [bucket-name]
   (let [bucket-arn (arn-of "aws_s3_bucket" bucket-name)]

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -8,7 +8,7 @@
                                        :bootcmd ["echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections"
                                                  "wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add -" ]
                                        :apt_mirror [{:source "deb ppa:webupd8team/java"}
-                                                    {:source "deb http://packages.elastic.co/logstash/2.2/debian stable main"
+                                                    {:source "deb http://packages.elastic.co/logstash/2.3/debian stable main"
                                                      :key (snippet "system-files/elasticsearch-apt.pem")                                                      }]
                                        :packages ["oracle-java8-installer"
                                                   "oracle-java8-set-default"
@@ -22,7 +22,10 @@
                                                       :content (snippet "vpc-logstash/in-beats.conf")}
                                                      {:path "/etc/logstash/conf.d/in-gelf.conf"
                                                       :permissions "644"
-                                                      :content (snippet "vpc-logstash/in-gelf.conf")}]}))
+                                                      :content (snippet "vpc-logstash/in-gelf.conf")}
+                                                     {:path "/opt/logstash/patterns/basic-batterns"
+                                                      :permissions "644"
+                                                      :content (snippet "vpc-logstash/basic-patterns")}]}))
 
 (defn elasticsearch-cluster [name {:keys [vpc-name account-number region azs default-ami vpc-cidr-block] :as spec}]
   ;; http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs

--- a/src/terraboot/vpc.clj
+++ b/src/terraboot/vpc.clj
@@ -269,5 +269,5 @@
              (output "sg-sends-gelf" "aws_security_group" (vpc-unique "sends_gelf") "id")
              (output "private-dns-zone" "aws_route53_zone" (vpc-unique "mesos") "id")
              (output "public-route-table" "aws_route_table" (vpc-unique "public") "id")
-             (output "logstash-ip" "aws_eip" (vpc-unique "logstash") "public_ip")
+             (output "logstash-ip" "aws_eip" (vpc-unique "logstash") "private_ip")
              ))))


### PR DESCRIPTION
assuming we use a certain logback format, this will:
- group multiline error
- grok (parse) the log level to a 'severity' field (ES seems to expect 'level' to be numerical)
