### PR TITLE
Adds: delete the exhibitor bucket on destroy

### DIFF
--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -322,7 +322,8 @@
                                      {:port 2181
                                       :source_security_group_id (cluster-id-of "aws_security_group" "lb-security-group")})
 
-             (cluster-resource "aws_s3_bucket" "exhibitor-s3-bucket" {:bucket (cluster-unique "exhibitor-s3-bucket")})
+             (cluster-resource "aws_s3_bucket" "exhibitor-s3-bucket" {:bucket (cluster-unique "exhibitor-s3-bucket")
+                                                                      :force_destroy true})
 
              (cluster-resource "aws_iam_user" "mesos-user" {:name "mesos-user"})
 


### PR DESCRIPTION
Without the :force_destroy you get the following error:
- aws_s3_bucket.sandpit-staging-exhibitor-s3-bucket: Error deleting S3 Bucket: BucketNotEmpty: The bucket you tried to delete is not empty
  status code: 409, request id: 335F9D5BC263A461
