### PR TITLE
application load balancer for public slaves instead of ELB

### DIFF
--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -308,6 +308,7 @@
                                      {:allow-all-sg (cluster-id-of "aws_security_group" "master-security-group")})
 
              (apply (partial cluster-security-group "public-slave-elb" {}) public-slave-elb-sg)
+             (apply (partial cluster-security-group "public-apps-alb" {}) public-slave-elb-sg)
 
              (cluster-security-group "public-slave-security-group" {}
                                      {:allow-all-sg (cluster-id-of "aws_security_group" "master-security-group")}
@@ -475,9 +476,12 @@
                    :subnets public-subnets
                    :lifecycle {:create_before_destroy true}
                    :default-security-groups remote-default-sgs
-                   :alb [{:name "public-slaves"
+                   :alb [{:name "public-apps"
                           :listeners (map #(assoc % :account-number account-number) public-slave-alb-listeners)
-                          :subnets public-subnets}]
+                          :subnets public-subnets
+                          :security-groups (concat [(cluster-id-of "aws_security_group" "public-slave-elb")
+                                                    (remote-output-of "vpc" "sg-allow-http-https")]
+                                                   remote-default-sgs)}]
                    :elb [{:name "public-slaves"
                           :health_check {:healthy_threshold 2
                                          :unhealthy_threshold 2

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -249,6 +249,7 @@
            public-slave-elb-listeners
            public-slave-elb-sg
            public-slave-elb-health
+           public-slave-alb-listeners
            account-number]}]
   (let [vpc-unique (vpc-unique-fn vpc-name)
         vpc-id-of (id-of-fn vpc-unique)
@@ -474,6 +475,9 @@
                    :subnets public-subnets
                    :lifecycle {:create_before_destroy true}
                    :default-security-groups remote-default-sgs
+                   :alb [{:name "public-slaves"
+                          :listeners (map #(assoc % :account-number account-number) public-slave-alb-listeners)
+                          :subnets public-subnets}]
                    :elb [{:name "public-slaves"
                           :health_check {:healthy_threshold 2
                                          :unhealthy_threshold 2

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -71,7 +71,8 @@
            (map (comp (partial add-to-resources-if-present "aws_security_group")
                       (partial add-to-resources-if-present "aws_internet_gateway")
                       (partial add-to-resources-if-present "aws_subnet")
-                      (partial add-to-resources-if-present "aws_route_table")) resources))))
+                      (partial add-to-resources-if-present "aws_route_table")
+                      (partial add-to-resources-if-present "aws_alb_target_group")) resources))))
 
 (def json-options {:key-fn name :pretty true})
 
@@ -257,14 +258,16 @@
                             :health_check_grace_period (spec :health_check_grace_period)
                             :launch_configuration (cluster-output-of "aws_launch_configuration" name "name")
                             :lifecycle { :create_before_destroy true }
-                            :load_balancers (mapv #(cluster-output-of "aws_elb" (:name %) "name") (:elb spec))
+                            :load_balancers (concat (mapv #(cluster-output-of "aws_elb" (:name %) "name") (:elb spec))
+                                                    (mapv #(cluster-output-of "aws_alb" {:name %}) (:alb spec)))
                             :tag {
                                   :key "Name"
                                   :value (name-fn name)
                                   :propagate_at_launch true
                                   }}))]
     (merge-in asg-config
-              (apply merge-in (map #(elb (:name %) cluster-resource %) (spec :elb))))))
+              (apply merge-in (map #(elb (:name %) cluster-resource %) (spec :elb)))
+              (apply merge-in (map #(alb name-fn %) (spec :alb))))))
 
 (def default-assume-policy
   (to-json {"Statement" [{"Action" ["sts:AssumeRole"]
@@ -378,3 +381,61 @@
 
 (defn remote-output-of [module name]
   (output-of (str "terraform_remote_state." module) "output" name))
+
+(defn alb-target-group
+  [cluster-resource
+   {:keys [protocol port name health_check]}]
+  (cluster-resource "aws_alb_target_group" name
+                    {:protocol protocol
+                     :port port
+                     :health_check health_check}))
+;; health_check https://www.terraform.io/docs/providers/aws/r/alb_target_group.html# sensible defaults
+
+(defn alb-listener
+  [name-fn {:keys [account-number protocol port alb-name name ssl-policy cert]}]
+  (let [cluster-resource (partial resource name-fn)
+        cluster-output-of (fn [type name output] (output-of type (name-fn name) output))
+        ssl-cert-arn (str "arn:aws:iam::" account-number ":server-certificate/" cert)
+        add-cert-if-present #(if cert (assoc % :certificate_arn ssl-cert-arn) %)
+        alb-arn (cluster-output-of "aws_alb" alb-name "arn")]
+    (cluster-resource "aws_alb_listener" name
+                      (add-cert-if-present {:load-balancer-arn alb-arn
+                                            :port port
+                                            :protocol protocol
+                                            :default_action {:target_group_arn (cluster-output-of "aws_alb_target_group" name "arn")
+                                                             :type "forward"}}))))
+
+(defn alb-sg
+  [name-fn name open-ports]
+  (apply (partial scoped-security-group name-fn
+                  (str name "-alb-sg")
+                  {})
+         (mapv #({:from_port (:port %)
+                  :to_port (:port %)
+                  :cidr_blocks [all-external]
+                  :protocol (:protocol %)}) open-ports)))
+
+(defn alb
+  [name-fn
+   {:keys [account-number
+           name
+           subnets
+           cluster-resource
+           listeners]}]
+  (let [cluster-resource (partial resource name-fn)]
+    (merge-in
+     (alb-sg name-fn (mapv #(select-keys % :port :protocol) listeners))
+     (cluster-resource "aws_alb" name
+                       {:security_groups [(id-of "aws_security_group" "allow_outbound")
+                                          (id-of "aws_security_group" (name-fn (str name "-alb-sg")))]
+                        :subnets subnets})
+     (apply merge-in
+            (mapv #(alb-target-group
+                    cluster-resource
+                    (select-keys % [:name :port :protocol :health_check])) listeners))
+     (apply merge-in
+            (mapv #(alb-listener
+                    name-fn
+                    (merge {:account-number account-number
+                            :alb-name name}
+                           (select-keys % [:name :port :protocol :ssl-policy :cert]))) listeners)))))

--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -429,4 +429,4 @@
                       :endpoint (get s3-endpoints region)}}))
 
 (defn remote-output-of [module name]
-  (output-of (str "terraform_remote_state." module) "output" name))
+  (output-of "terraform_remote_state" module name))

--- a/src/terraboot/public_dns.clj
+++ b/src/terraboot/public_dns.clj
@@ -33,10 +33,10 @@
         cluster-output-of (core/output-of-fn cluster-unique)]
     (utils/merge-in
      (route53-record (cluster-unique "deploy")
-                     {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
-                              :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
+                     {:alias {:name (cluster-output-of "aws_alb" "public-apps" "dns_name")
+                              :zone_id (cluster-output-of "aws_alb" "public-apps" "zone_id")
                               :evaluate_target_health true}})
      (route53-record cluster-identifier
-                     {:alias {:name (cluster-output-of "aws_elb" "public-slaves" "dns_name")
-                              :zone_id (cluster-output-of "aws_elb" "public-slaves" "zone_id")
+                     {:alias {:name (cluster-output-of "aws_alb" "public-apps" "dns_name")
+                              :zone_id (cluster-output-of "aws_alb" "public-apps" "zone_id")
                               :evaluate_target_health true}}))))


### PR DESCRIPTION
Application Load Balancers (ALB) suit our use of public slaves better - the idea is to have target groups for every app (port) and ALB health checks them individually (whereas an ELB has one health check for all and removes all unhealthy instances).  Every target group is linked to a listener under the ALB.
