### PR TITLE
make sure target groups get autoscaling group instances

### DIFF
--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -331,7 +331,7 @@
                             :launch_configuration (cluster-output-of "aws_launch_configuration" name "name")
                             :lifecycle { :create_before_destroy true }
                             :load_balancers (mapv #(cluster-output-of "aws_elb" (:name %) "name") (:elb spec))
-                            :target_group_arns (mapv #(cluster-output-of "aws_alb_target_group" (:name %) "arn") (:listeners (spec :alb)))
+                            :target_group_arns (mapv #(cluster-output-of "aws_alb_target_group" (:name %) "arn") (mapcat :listeners (:alb spec)))
                             :tag {:key "Name"
                                   :value (name-fn name)
                                   :propagate_at_launch true


### PR DESCRIPTION
fix because the :alb parameter actually gets a list of maps instead of a single map.  All the application load balancers added should get all the instances of the autoscaling groups for all their target groups.