### PR TITLE
Fix/logstash es cycle

### DIFF
--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -374,6 +374,7 @@
                    :elb [{:name "internal-lb"
                           :listeners [(elb-listener {:port 80 :protocol "HTTP"})
                                       (elb-listener {:port 2181 :protocol "TCP"})
+                                      (elb-listener {:port 8181 :protocol "TCP"})
                                       (elb-listener {:port 53 :protocol "TCP"})]
                           :health_check {:healthy_threshold 2
                                          :unhealthy_threshold 3

--- a/src/terraboot/elasticsearch.clj
+++ b/src/terraboot/elasticsearch.clj
@@ -27,6 +27,21 @@
                                                       :permissions "644"
                                                       :content (snippet "vpc-logstash/basic-patterns")}]}))
 
+(defn elasticsearch-policy
+  []
+  (json/generate-string {"Version" "2012-10-17",
+                         "Statement" [{"Action" "es:*",
+                                       "Principal" "*",
+                                       "Resource" "$${es-arn}",
+                                       ;; There is currently a bug which means 'Resource' needs adding after the
+                                       ;; cluster is created or it will constantly say it needs to change.
+                                       ;; https://github.com/hashicorp/terraform/issues/5067
+                                       "Effect" "Allow",
+                                       "Condition"
+                                       {
+                                        "IpAddress"
+                                        {"aws:SourceIp" "$${allowed-ips}"}}}]}))
+
 (defn elasticsearch-cluster [name {:keys [vpc-name account-number region azs default-ami vpc-cidr-block cert-name] :as spec}]
   ;; http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs
   ;; See for what instance-types and storage is possible
@@ -35,26 +50,20 @@
         vpc-id-of (id-of-fn vpc-unique)
         vpc-output-of (output-of-fn vpc-unique)
         vpc-security-group (partial scoped-security-group vpc-unique)
-        elb-listener (account-elb-listener account-number)]
+        elb-listener (account-elb-listener account-number
+                                           )]
     (merge-in
+     (template-file (vpc-unique "elasticearch-policy")
+                    {:es-arn (str "arn:aws:es:" region ":" account-number ":domain/" vpc-name "-elasticsearch/*"),
+                     :allowed-ips  (concat
+                                    (mapv #(vpc-output-of "aws_eip" (stringify "public-" % "-nat") "public_ip") azs)
+                                    [(vpc-output-of "aws_eip" "logstash" "public_ip")])})
+
      (vpc-resource "aws_elasticsearch_domain" name
                    {:domain_name (vpc-unique name)
                     :advanced_options { "rest.action.multi.allow_explicit_index" true}
-                    :access_policies (json/generate-string {"Version" "2012-10-17",
-                                                            "Statement" [{"Action" "es:*",
-                                                                          "Principal" "*",
-                                                                          "Resource" (str "arn:aws:es:" region ":" account-number ":domain/" vpc-name "-elasticsearch/*"),
-                                                                          ;; There is currently a bug which means 'Resource' needs adding after the
-                                                                          ;; cluster is created or it will constantly say it needs to change.
-                                                                          ;; https://github.com/hashicorp/terraform/issues/5067
-                                                                          "Effect" "Allow",
-                                                                          "Condition"
-                                                                          {
-                                                                           "IpAddress"
-                                                                           {"aws:SourceIp" (concat
-                                                                                            (mapv #(vpc-output-of "aws_eip" (stringify "public-" % "-nat") "public_ip") azs)
-                                                                                            [(vpc-output-of "aws_eip" "logstash" "public_ip")])
-                                                                            }}}]})
+                    :access_policies (rendered-template-file (vpc-unique "elasticsearch-policy"))
+
                     :cluster_config {:instance_count 2,
                                      :instance_type "t2.small.elasticsearch"}
                     :ebs_options {:ebs_enabled true,

--- a/src/terraboot/public_dns.clj
+++ b/src/terraboot/public_dns.clj
@@ -17,7 +17,7 @@
   (let [route53-record (partial public-route53-record dns-zone dns-zone-id)
         vpc-output-of (core/output-of-fn (core/vpc-unique-fn vpc-name))]
     (utils/merge-in
-     (route53-record "vpn" {:records [(vpc-output-of "aws_instance" "vpn" "public_ip")]})
+     (route53-record "vpn" {:records [(vpc-output-of "aws_eip" "vpn" "public_ip")]})
      (route53-record "logstash" {:records [(vpc-output-of "aws_eip" "logstash" "public_ip")]})
      (route53-record "grafana" {:type "CNAME"
                                 :records [(core/output-of "aws_elb" "grafana" "dns_name")]})


### PR DESCRIPTION
* fix cycle between logstash and ES configuration (not completely resolved, needs manual intervention to elasticsearch to add policy to allow logstash to contribute logs)
* add listener for port 8181 because it's needed for DNS (dcos-spartan)
* fix logstash setup to be closer to automating setup
* point vpn.mastodonc.net to EIP instead of public ip of instance