### PR TITLE
Fix/filebeat filter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,12 @@
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :creds :gpg}]
                  ["snapshots" {:url "https://clojars.org/repo"
-                               :creds :gpg}]])
+                               :creds :gpg}]]
+  :release-tasks [["vcs" "assert-committed"]
+                  ["change" "version"
+                   "leiningen.release/bump-version" "release"]
+                  ["vcs" "commit"]
+                  ["vcs" "tag"]
+                  ["change" "version" "leiningen.release/bump-version"]
+                  ["vcs" "commit"]
+                  ["vcs" "push"]])

--- a/resources/systemd/filebeat.service
+++ b/resources/systemd/filebeat.service
@@ -6,5 +6,5 @@ After=network-online.target
 [Service]
 TimeoutStartSec=15
 StartLimitInterval=0
-ExecStart=/bin/sh -c "/usr/bin/journalctl -b -o json -f | /opt/bin/filebeat -c /etc/beats/filebeat.yml"
+ExecStart=/bin/sh -c "/usr/bin/journalctl -b -u docker.service -u dcos-cluster-id.service -u dcos-ddt.service -u dcos-exhibitor.service -u dcos-marathon.service -u dcos-mesos-dns.service -u dcos-mesos-master.service -u dcos-mesos-slave-public.service -u dcos-mesos-slave.service -u dcos-signal.service -u dcos-spartan-watchdog.service -o json -f | /opt/bin/filebeat -c /etc/beats/filebeat.yml"
 Restart=always


### PR DESCRIPTION
![log-volumes](https://cloud.githubusercontent.com/assets/8934/23367294/ab8192ea-fd01-11e6-8700-e135af1b07b8.png)
fix to only log what we want to see from the system logs (most importantly the docker ones!)