### PR TITLE
every 5 minutes

### DIFF
--- a/resources/system-files/metricbeat.yml
+++ b/resources/system-files/metricbeat.yml
@@ -21,7 +21,7 @@ metricbeat.modules:
     - process
     - socket
   enabled: true
-  period: 60s
+  period: 300s
   processes: ['.*']
 
 #------------------------------- Docker Module -------------------------------
@@ -29,4 +29,4 @@ metricbeat.modules:
   metricsets: ["cpu", "info", "memory", "network", "diskio", "container"]
   hosts: ["unix:///var/run/docker.sock"]
   enabled: true
-  period: 60s
+  period: 300s


### PR DESCRIPTION
this is a proposal: metricbeat logs between 1.2 and 2GB/day in elasticsearch at the moment, wondering if we could have metrics once very 5 minutes?