### PR TITLE
Throw an exception if a snippet resource is not found.

### DIFF
--- a/src/terraboot/core.clj
+++ b/src/terraboot/core.clj
@@ -371,7 +371,10 @@
   (mustache/render-file template-name vars))
 
 (defn snippet [path]
-  (slurp (clojure.java.io/resource path)))
+  (let [snippet-file (clojure.java.io/resource path)]
+    (if (nil? snippet-file)
+      (throw (Exception. (str "No resource found: " path)))
+      (slurp snippet-file))))
 
 (defn database [{:keys [name subnet] :as spec}]
   (merge-in


### PR DESCRIPTION
**Throw an exception if a snippet resource is not found.**