### PR TITLE
Create an internal ALB only if there is demand

### DIFF
--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -488,7 +488,7 @@
                              :security-groups (concat [(cluster-id-of "aws_security_group" "slave-alb-sg")]
                                                       remote-default-sgs)}]
                            [])})
-              (if (seq slave-alb-listeners)
+              (when (seq slave-alb-listeners)
                 (vpc/private-route53-record "slaves"
                                             environment-dns
                                             environment-dns-identifier

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -480,16 +480,21 @@
                     :subnets private-subnets
                     :lifecycle {:create_before_destroy true}
                     :elb []
-                    :alb [{:name "internal-tasks"
-                           :internal true
-                           :listeners (map #(assoc % :account-number account-number) slave-alb-listeners)
-                           :subnets elb-private-subnets
-                           :security-groups (concat [(cluster-id-of "aws_security_group" "slave-alb-sg")]
-                                                    remote-default-sgs)}] })
-              (vpc/private-route53-record "slaves"
-                                          environment-dns
-                                          environment-dns-identifier
-                                          {:zone_id (remote-output-of "vpc" "private-dns-zone")
-                                           :alias {:name (cluster-output-of "aws_alb" "internal-tasks" "dns_name")
-                                                   :zone_id (cluster-output-of "aws_alb" "internal-tasks" "zone_id")
-                                                   :evaluate_target_health true}}))))))
+                    :alb (let [listeners (map #(assoc % :account-number account-number) slave-alb-listeners)]
+                           (if (seq listeners)
+                             [{:name "internal-tasks"
+                               :internal true
+                               :listeners listeners
+                               :subnets elb-private-subnets
+                               :security-groups (concat [(cluster-id-of "aws_security_group" "slave-alb-sg")]
+                                                        remote-default-sgs)}]
+                             []))})
+              (let [listeners (map #(assoc % :account-number account-number) slave-alb-listeners)]
+                (if (seq listeners)
+                  (vpc/private-route53-record "slaves"
+                                              environment-dns
+                                              environment-dns-identifier
+                                              {:zone_id (remote-output-of "vpc" "private-dns-zone")
+                                               :alias {:name (cluster-output-of "aws_alb" "internal-tasks" "dns_name")
+                                                       :zone_id (cluster-output-of "aws_alb" "internal-tasks" "zone_id")
+                                                       :evaluate_target_health true}}))))))))

--- a/src/terraboot/cluster.clj
+++ b/src/terraboot/cluster.clj
@@ -480,21 +480,19 @@
                     :subnets private-subnets
                     :lifecycle {:create_before_destroy true}
                     :elb []
-                    :alb (let [listeners (map #(assoc % :account-number account-number) slave-alb-listeners)]
-                           (if (seq listeners)
-                             [{:name "internal-tasks"
-                               :internal true
-                               :listeners listeners
-                               :subnets elb-private-subnets
-                               :security-groups (concat [(cluster-id-of "aws_security_group" "slave-alb-sg")]
-                                                        remote-default-sgs)}]
-                             []))})
-              (let [listeners (map #(assoc % :account-number account-number) slave-alb-listeners)]
-                (if (seq listeners)
-                  (vpc/private-route53-record "slaves"
-                                              environment-dns
-                                              environment-dns-identifier
-                                              {:zone_id (remote-output-of "vpc" "private-dns-zone")
-                                               :alias {:name (cluster-output-of "aws_alb" "internal-tasks" "dns_name")
-                                                       :zone_id (cluster-output-of "aws_alb" "internal-tasks" "zone_id")
-                                                       :evaluate_target_health true}}))))))))
+                    :alb (if (seq slave-alb-listeners)
+                           [{:name "internal-tasks"
+                             :internal true
+                             :listeners (map #(assoc % :account-number account-number) slave-alb-listeners)
+                             :subnets elb-private-subnets
+                             :security-groups (concat [(cluster-id-of "aws_security_group" "slave-alb-sg")]
+                                                      remote-default-sgs)}]
+                           [])})
+              (if (seq slave-alb-listeners)
+                (vpc/private-route53-record "slaves"
+                                            environment-dns
+                                            environment-dns-identifier
+                                            {:zone_id (remote-output-of "vpc" "private-dns-zone")
+                                             :alias {:name (cluster-output-of "aws_alb" "internal-tasks" "dns_name")
+                                                     :zone_id (cluster-output-of "aws_alb" "internal-tasks" "zone_id")
+                                                       :evaluate_target_health true}})))))))


### PR DESCRIPTION
Path: plan.bin

- aws_alb.sandpit-staging-internal-tasks

- aws_alb_listener.sandpit-staging-elasticsearch

- aws_alb_target_group.sandpit-staging-elasticsearch

~ aws_autoscaling_group.sandpit-staging-slaves
    target_group_arns.#:         "1" => "0"
    target_group_arns.290326498: "arn:aws:elasticloadbalancing:eu-central-1:165664414043:targetgroup/sandpit-staging-elasticsearch/df0219a19cd88002" => ""

- aws_route53_record.slaves__staging__witan__mastodonc__net

- aws_security_group_rule.sandpit-staging-slave-alb-sg--1899968026


Plan: 0 to add, 1 to change, 5 to destroy.

**Create an internal ALB only if there is demand**